### PR TITLE
Readme: Update version number and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,31 @@
 
 ## Installation Instructions
 
-NOTE: This project utilizes a local MySQL server. If you do not have MySQL installed on your machine, you will need to install it before running the application. You can download MySQL from the official website: https://dev.mysql.com/downloads/
+NOTE: This project utilizes a local MySQL server. If you do not have MySQL installed on your machine, you will need to install it before running the application. You can download MySQL from the official website: https://dev.mysql.com/downloads/installer/
 
-1. Install Python 3.12 on your machine. You can download the latest version of Python from the official website: https://www.python.org/downloads/
-2. install pipenv if you don't have it installed already. You can install pipenv by running one of the following commands in your terminal:
+## Installing Python and pipenv
+1. Download and install **Python 3.12** from the official website: https://www.python.org/downloads/
+2. Open a terminal and run one of the following commands to install pipenv:
     - `pip install pipenv` (for Windows)
-    - `pip3 install pipenv` (for MacOS)
-3. Clone the repository to your local machine.
-4. Navigate to the project directory in your terminal.
-5. Run `pipenv install` to install the project dependencies.
-6. Run `pipenv shell` to activate the virtual environment.
-7. Run the file: page_turners.sql to create the database schema.
-8. Run `python server.py` to start the development server.
-9. Open your web browser and navigate to `http://localhost:5001/` to view the application.
-(Note that the application is using port 5001 to avoid conflicts with MacOS.)
+    - `pip3 install pipenv`(for MacOS)
+    (Note: Linux users can use either command)
+3. Navigate to the project directory in your terminal, and run the following command to install the project dependencies:
+    - `pipenv install`
 
+## Setting up the MySQL Database
+1. Download and install MySQL from the official website: https://dev.mysql.com/downloads/installer/
+- Make sure to install both MySQL Server and MySQL Workbench.
+- Write down the root password you set during installation. This will be needed to connect to the MySQL server.
+- Do *not* use port 5001 for the MySQL server. This port is used by the Flask application.
+2. Open MySQL Workbench and create a new connection to your local MySQL server.
+3. Click File > Open SQL Script, and select the `page_turners.sql` file from the project directory.
+4. Run the script (Click on the lightning bolt next to the save icon) to create the database and tables.
 
+## Running / Testing the Application
+1. Open a terminal and navigate to the project directory.
+2. Run the following command to activate the virtual environment:
+    - `pipenv shell`
+3. Run the following command to start the development server:
+    - `python server.py`
+4. Open a web browser and navigate to `http://localhost:5001/` to access the application.
+5. Register a new account using the landing page, click logout, and then verify that you can log in with the new account.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 NOTE: This project utilizes a local MySQL server. If you do not have MySQL installed on your machine, you will need to install it before running the application. You can download MySQL from the official website: https://dev.mysql.com/downloads/
 
-1. Install Python 3 on your machine. You can download the latest version of Python from the official website: https://www.python.org/downloads/
+1. Install Python 3 (3.12 or higher) on your machine. You can download the latest version of Python from the official website: https://www.python.org/downloads/
 2. install pipenv if you don't have it installed already. You can install pipenv by running one of the following commands in your terminal:
     - `pip install pipenv` (for Windows)
     - `pip3 install pipenv` (for MacOS)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 NOTE: This project utilizes a local MySQL server. If you do not have MySQL installed on your machine, you will need to install it before running the application. You can download MySQL from the official website: https://dev.mysql.com/downloads/
 
-1. Install Python 3 (3.12 or higher) on your machine. You can download the latest version of Python from the official website: https://www.python.org/downloads/
+1. Install Python 3.12 on your machine. You can download the latest version of Python from the official website: https://www.python.org/downloads/
 2. install pipenv if you don't have it installed already. You can install pipenv by running one of the following commands in your terminal:
     - `pip install pipenv` (for Windows)
     - `pip3 install pipenv` (for MacOS)


### PR DESCRIPTION
I realized in testing the instructions that my system was using Python 3.8.8. Our project can only function on at minimum Python 3.12. 

Also, the installation instructions are missing crucial details for setup. MySQL Workbench requires the user to also install MySQL server to bridge pymysql and the database.