### PR TITLE
Update user dashboard, Make Creation/Editing books admin only

### DIFF
--- a/flask_app/templates/dashboard.html
+++ b/flask_app/templates/dashboard.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Dashboard</title>
+  <title>User Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
   <link rel="stylesheet" href="/static/styles/theme.css">
@@ -23,7 +23,6 @@
         <label class="form-check-label px-2 fs-5" id="themeSwitchLabel" for="themeSwitch">Dark Mode</label>
       </div>
       <a href="#" class="icon" alt="Cart"><external-svg src="/static/svg/functional/shopping-cart.svg"></a>
-      <a href="/book/new" class="icon" alt="Add a New Book"><external-svg src="/static/svg/functional/book.svg"></a>
       <a href="/users/logout" class="icon" alt="Log Out"><external-svg src="/static/svg/functional/logout.svg"></a>
     </nav>
   </div>

--- a/flask_app/templates/edit_book.html
+++ b/flask_app/templates/edit_book.html
@@ -56,7 +56,7 @@
           </div>
           <input type="hidden" name="user_id" value="{{session['user_id']}}" />
           <div class="d-flex gap-3 mb-5">
-            <a href="/dashboard" class="btn btn-lg btn-warning">Cancel</a>
+            <a href="/admin_dashboard" class="btn btn-lg btn-warning">Cancel</a>
             <button class="btn btn-lg btn-primary" type="submit">Submit</button>
           </div>
         </form>

--- a/flask_app/templates/new_book.html
+++ b/flask_app/templates/new_book.html
@@ -56,7 +56,7 @@
           </div>
           <input type="hidden" name="user_id" value="{{ session['user_id'] }}" />
           <div class="d-flex gap-3 mb-5">
-            <a href="/dashboard" class="btn btn-lg btn-warning">Cancel</a>
+            <a href="/admin_dashboard" class="btn btn-lg btn-warning">Cancel</a>
             <button class="btn btn-lg btn-primary" type="submit">Submit</button>
           </div>
         </form>


### PR DESCRIPTION
Updated the internal page title to "User Dashboard" (was "Dashboard") Removed the Add book button from the User Dashboard. Changed frontend routing to send admins back to admin dashboard when creating/editing books.